### PR TITLE
Switch project type to Portable Class Library & make necessary changes

### DIFF
--- a/src/Fluent-CQRS/AggregateLifeCycle.cs
+++ b/src/Fluent-CQRS/AggregateLifeCycle.cs
@@ -71,11 +71,10 @@ namespace Fluent_CQRS
 			try {
 				var aggregateId = _aggregate.Id;
 
-				_aggregate
-                    .Changes
-                    .ToList ()
-                    .ForEach (eventMessage =>
-                        _eventStore.StoreFor (aggregateId, eventMessage));
+			    foreach (var eventMessage in _aggregate.Changes)
+			    {
+			        _eventStore.StoreFor(aggregateId, eventMessage);
+			    }
 
 				executionResult.Saved = true;
 			} catch (Exception ex) {

--- a/src/Fluent-CQRS/EventHandlers.cs
+++ b/src/Fluent-CQRS/EventHandlers.cs
@@ -19,7 +19,10 @@ namespace Fluent_CQRS
 
 		public void Receive (IEnumerable<IAmAnEventMessage> events)
 		{
-			_receiver.ToList ().ForEach (receiver => receiver.Receive (events));
+		    foreach (var receiver in _receiver)
+		    {
+		        receiver.Receive (events);
+		    }
 		}
 
 		public IConcatenateEventHandler And (IHandleEvents eventHandler)

--- a/src/Fluent-CQRS/Extensions/EventExtension.cs
+++ b/src/Fluent-CQRS/Extensions/EventExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using System.Reflection;
 
@@ -13,7 +12,7 @@ namespace Fluent_CQRS.Extensions
 			var eventType = @event.GetType ();
 
 			var eventHandlerMethods =
-                from method in handlerType.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public)
+                from method in handlerType.GetTypeInfo().DeclaredMethods
 				from parameter in method.GetParameters ()
 				where parameter.ParameterType == eventType
 				select method;

--- a/src/Fluent-CQRS/Fluent-CQRS.csproj
+++ b/src/Fluent-CQRS/Fluent-CQRS.csproj
@@ -10,7 +10,8 @@
     <RootNamespace>Fluent_CQRS</RootNamespace>
     <AssemblyName>Fluent-CQRS</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -108,7 +109,7 @@
     <Compile Include="Extensions\EventExtension.cs" />
     <Compile Include="MultipleHandlerMethodesDetected.cs" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Hi Janek,

ich teste das Fluent CQRS gerade im Zusammenhang mit portablen Projekten (Xamarin, Windows Phone, Windows Universal App). Dazu müsste aber die Bibliothek als Portable Class Library existieren.

Die im PR enthaltenen Änderungen compilieren und die Tests sind auch grün. :)


Viele Grüße,
Andreas