### PR TITLE
Fix NuGet target folder 

### DIFF
--- a/scripts/build-solution.fsx
+++ b/scripts/build-solution.fsx
@@ -88,7 +88,7 @@ Target "Package" (fun _ ->
             Version = version
             OutputPath = publishDir
             WorkingDir = publishDir
-            Files = [builtAssembly, Some "lib/net45", None] })
+            Files = [builtAssembly, Some "lib/portable-net45+netcore45+wpa81", None] })
             "src/package.nuspec"
 )
 


### PR DESCRIPTION
In order to instal Fluent-CQRS Package as a dependency in a Portable Class Library the target folder has to be changed from lib/net45 to lib/portable-net45+netcore45+wpa81.