### PR TITLE
 Renamed most replay functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,24 @@
 # fluent-cqrs
 "The Next Generation" CQRS Framework for .Net applications
 
-### Attenzione Attenzione: 
-There is an **Api break**. The method `OnError` was splitted into `CatchException` 
+### Attenzione Attenzione:
+There is an **Api break**. The method `OnError` was splitted into `CatchException`
 (raised by unexpected System Exceptions) and `CatchFault` (raised by Business Faults)
+By default 'Do' throws all exceptions directly. Use 'Try' for catching errors.
 
 ---
 
 Why fluent? Just look at this:
 
-    public class AwsomeCommandHandler 
+    public class AwsomeCommandHandler
     {
         Aggregates _aggregates;
-        
+
         public AwsomeCommandHandler(Aggregates aggregates)
         {
             _aggregates = aggregates;
         }
-      
+
         public void Handle(SuperDuperCommand command)
         {
             _aggregates
@@ -41,8 +42,7 @@ Why fluent? Just look at this:
 			    .With(command.AggregateId)
 			    .Try(yourAggregate => yourAggregate.DoSomethingWith(command.Data))
 			    .CatchFault(fault=> handleThis(fault))
-				.CatchException(exception => handleThis(exception));
-
+				  .CatchException(exception => handleThis(exception));
         }
     }
 
@@ -52,24 +52,24 @@ Uhhh... this is the **complete handling** of a Domain Command.
 
 Ok, but what do I have to do to **publish** the new state, aka **Domain Events**?
 
-This is simple. You assign any Event Handler you like by chaining it by the `And` method after `PublishNewStateTo`. 
+This is simple. You assign any Event Handler you like by chaining it by the `And` method after `PublishNewStateTo`.
 For example you have three Event Handlers:
 
     var _aggregates = Aggregates.CreateWith(yourExtremeGoodEventStoreInstance);
     var firstEventHandler = new SampleEventHandler();
     var secondEventHandler = new ReportingHandler();
     var thirdEventHandler = new LoggingHandler();
-    
+
     _aggregates
         .PublishNewStateTo(firstEventHandler)
         .And(secondEventHandler)
         .And(thirdEventHandler);
-    
+
 now all your cool Event Handlers receiving all changes of an aggregate.
 
 ---
 
-All right... In some cases you want to save an event only once, but if you add the event into the list of Changes like this: 
+All right... In some cases you want to save an event only once, but if you add the event into the list of Changes like this:
 
     class CoolAggregate() : Aggregate
     {
@@ -107,16 +107,16 @@ Nice, realy nice... But what if you want to replay all Events of an Aggregate? Y
 To replay all Events of an Aggregate code this:
 
     _aggregates
-        .ReplayEventsFor<[AnAggregateYouLike]>()
-        .WithId(aggrId)
+        .ReplayFor<[AnAggregateYouLike]>()
+        .EventsWithAggregateId(aggrId)
         .ToAllEventHandlers();
 
 This published all Events of the Aggregate with the given ID to all registered Event Handler.
 If you want to publish to only one special Event Handler change your Code to:
 
     _aggregates
-        .ReplayEventsFor<[AnAggregateYouLike]>()
-        .WithId(aggrId)
+        .ReplayFor<[AnAggregateYouLike]>()
+        .EventsWithAggregateId(aggrId)
         .To([OneOfYourEventHandler]);
 
 This ist simple, as well.
@@ -125,20 +125,19 @@ This ist simple, as well.
 You can also replay events of an aggregate type:
 
     _aggregates
-        .ReplayEventsFor<[AnAggregateYouLike]>()
-        .All()
+        .ReplayFor<[AnAggregateYouLike]>()
+        .AllEvents()
         .ToAllEventHandlers();
 
 
 You can also filter for certain event messages:
 
     _aggregates
-        .ReplayEventsFor<[AnAggregateYouLike]>()
-        .All()
-		.OfMessageType<SomethingHappend>()
+        .ReplayFor<[AnAggregateYouLike]>()
+        .AllEvents()
+		    .OfType<[AnEvent]>()
         .ToAllEventHandlers();
 
 
 ---
 ~tbc
-

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ### Attenzione Attenzione:
 There is an **Api break**. The method `OnError` was splitted into `CatchException`
-(raised by unexpected System Exceptions) and `CatchFault` (raised by Business Faults)
+(raised by unexpected System Exceptions) and `CatchFault` (raised by Business Faults).
 By default 'Do' throws all exceptions directly. Use 'Try' for catching errors.
 
 ---
@@ -26,23 +26,23 @@ Why fluent? Just look at this:
                 .With(command.AggregateId)
                 .Do(yourAggregate => yourAggregate.DoSomethingWith(command.Data));
 
-		    // You want it with exception handling?
-		    // Lets do it
+            // You want it with exception handling?
+            // Lets do it
 
-		    _aggregates
-			    .Provide<[AnAggregateYouLike]>
-			    .With(command.AggregateId)
-			    .Try(yourAggregate => yourAggregate.DoSomethingWith(command.Data))
-			    .CatchException(exception=> handleThis(exception));
+            _aggregates
+                .Provide<[AnAggregateYouLike]>
+                .With(command.AggregateId)
+                .Try(yourAggregate => yourAggregate.DoSomethingWith(command.Data))
+                .CatchException(exception=> handleThis(exception));
 
-			// And here a very simple way to catch business faults which thrown within the Aggregate
+            // And here a very simple way to catch business faults which thrown within the Aggregate
 
-			_aggregates
-			    .Provide<[AnAggregateYouLike]>
-			    .With(command.AggregateId)
-			    .Try(yourAggregate => yourAggregate.DoSomethingWith(command.Data))
-			    .CatchFault(fault=> handleThis(fault))
-				  .CatchException(exception => handleThis(exception));
+            _aggregates
+                .Provide<[AnAggregateYouLike]>
+                .With(command.AggregateId)
+                .Try(yourAggregate => yourAggregate.DoSomethingWith(command.Data))
+                .CatchFault(fault=> handleThis(fault))
+                .CatchException(exception => handleThis(exception));
         }
     }
 
@@ -121,7 +121,6 @@ If you want to publish to only one special Event Handler change your Code to:
 
 This ist simple, as well.
 
-
 You can also replay events of an aggregate type:
 
     _aggregates
@@ -129,15 +128,13 @@ You can also replay events of an aggregate type:
         .AllEvents()
         .ToAllEventHandlers();
 
-
 You can also filter for certain event messages:
 
     _aggregates
         .ReplayFor<[AnAggregateYouLike]>()
         .AllEvents()
-		    .OfType<[AnEvent]>()
+        .OfType<[AnEvent]>()
         .ToAllEventHandlers();
-
 
 ---
 ~tbc

--- a/src/Fluent-CQRS.Tests/AggregatesRepositoryTests.cs
+++ b/src/Fluent-CQRS.Tests/AggregatesRepositoryTests.cs
@@ -30,8 +30,8 @@ namespace Fluent_CQRS.Tests
             _eventHandler.RecievedEvents.Clear();
 
             _aggregates
-                .ReplayEventsFor<TestAggregate>()
-                .WithId(aggrId)
+                .ReplayFor<TestAggregate>()
+                .EventsWithAggregateId(aggrId)
                 .ToAllEventHandlers();
 
             _eventHandler.RecievedEvents.Count.Should().Be(4);
@@ -53,8 +53,8 @@ namespace Fluent_CQRS.Tests
             var alternativeEventHandler = new AlternativeTestEventHandler();
 
             _aggregates
-                .ReplayEventsFor<TestAggregate>()
-                .WithId(aggrId)
+                .ReplayFor<TestAggregate>()
+                .EventsWithAggregateId(aggrId)
                 .To(alternativeEventHandler);
 
             _eventHandler.RecievedEvents.Count.Should().Be(4);
@@ -86,8 +86,8 @@ namespace Fluent_CQRS.Tests
             _eventHandler.RecievedEvents.Clear();
 
             _aggregates
-                .ReplayEventsFor<TestAggregate>()
-                .WithId(aggrId)
+                .ReplayFor<TestAggregate>()
+                .EventsWithAggregateId(aggrId)
                 .ToAllEventHandlers();
 
             _eventHandler.RecievedEvents.Count.Should().Be(4);
@@ -117,9 +117,9 @@ namespace Fluent_CQRS.Tests
             _eventHandler.RecievedEvents.Clear();
 
             _aggregates
-                .ReplayEventsFor<TestAggregate>()
-                .WithId(aggrId)
-                .OfMessageType<SomethingHappend>()
+                .ReplayFor<TestAggregate>()
+                .EventsWithAggregateId(aggrId)
+                .OfType<SomethingHappend>()
                 .ToAllEventHandlers();
 
             _eventHandler.RecievedEvents.Count.Should().Be(1);
@@ -150,8 +150,8 @@ namespace Fluent_CQRS.Tests
             _eventHandler.RecievedEvents.Clear();
 
             _aggregates
-                .ReplayEventsFor<TestAggregate>()
-                .All()
+                .ReplayFor<TestAggregate>()
+                .AllEvents()
                 .ToAllEventHandlers();
 
             _eventHandler.RecievedEvents.Count.Should().Be(2);
@@ -180,8 +180,8 @@ namespace Fluent_CQRS.Tests
             _eventHandler.RecievedEvents.Clear();
 
             _aggregates
-                .ReplayEventsFor<TestAggregate>()
-                .All()
+                .ReplayFor<TestAggregate>()
+                .AllEvents()
                 .ToAllEventHandlers();
 
             _eventHandler.RecievedEvents.Count.Should().Be(1);

--- a/src/Fluent-CQRS.Tests/Fluent-CQRS.Tests.csproj
+++ b/src/Fluent-CQRS.Tests/Fluent-CQRS.Tests.csproj
@@ -58,7 +58,7 @@
     <Compile Include="Infrastructure\BusinessFault.cs" />
     <Compile Include="Infrastructure\SomethingHappend.cs" />
     <Compile Include="Infrastructure\SomethingHappendOnce.cs" />
-    <Compile Include="Infrastructure\SomtethingSpecialHappend.cs" />
+    <Compile Include="Infrastructure\SomethingSpecialHappend.cs" />
     <Compile Include="Infrastructure\TestAggregate.cs" />
     <Compile Include="Infrastructure\TestCommand.cs" />
     <Compile Include="Infrastructure\TestEventHandler.cs" />

--- a/src/Fluent-CQRS.Tests/Infrastructure/SomethingSpecialHappend.cs
+++ b/src/Fluent-CQRS.Tests/Infrastructure/SomethingSpecialHappend.cs
@@ -1,0 +1,7 @@
+namespace Fluent_CQRS.Tests.Infrastructure
+{
+    public class SomethingSpecialHappend : IAmAnEventMessage
+    {
+        public string NiceProperty { get; set; }
+    }
+}

--- a/src/Fluent-CQRS.Tests/Infrastructure/SomtethingSpecialHappend.cs
+++ b/src/Fluent-CQRS.Tests/Infrastructure/SomtethingSpecialHappend.cs
@@ -1,7 +1,0 @@
-namespace Fluent_CQRS.Tests.Infrastructure
-{
-    public class SomtethingSpecialHappend : IAmAnEventMessage
-    {
-        public string NiceProperty { get; set; }
-    }
-}

--- a/src/Fluent-CQRS.Tests/Infrastructure/TestAggregate.cs
+++ b/src/Fluent-CQRS.Tests/Infrastructure/TestAggregate.cs
@@ -45,22 +45,22 @@ namespace Fluent_CQRS.Tests.Infrastructure
 
         public void DoFourActions()
         {
-            Changes.Add(new SomtethingSpecialHappend
+            Changes.Add(new SomethingSpecialHappend
             {
                 NiceProperty = "Test1"
             });
 
-            Changes.Add(new SomtethingSpecialHappend
+            Changes.Add(new SomethingSpecialHappend
             {
                 NiceProperty = "Test2"
             });
 
-            Changes.Add(new SomtethingSpecialHappend
+            Changes.Add(new SomethingSpecialHappend
             {
                 NiceProperty = "Test3"
             });
 
-            Changes.Add(new SomtethingSpecialHappend
+            Changes.Add(new SomethingSpecialHappend
             {
                 NiceProperty = "Test4"
             });

--- a/src/Fluent-CQRS/Aggregates.cs
+++ b/src/Fluent-CQRS/Aggregates.cs
@@ -31,7 +31,7 @@ namespace Fluent_CQRS
 			return _eventHandlers;
 		}
 
-        public ICollectEvents ReplayEventsFor<TAggregate>() where TAggregate : Aggregate
+        public ICollectEvents ReplayFor<TAggregate>() where TAggregate : Aggregate
 	    {
 	        return new PlaybackEvents<TAggregate>(_eventStore, ReplayCallback);
 	    }

--- a/src/Fluent-CQRS/ICollectEvents.cs
+++ b/src/Fluent-CQRS/ICollectEvents.cs
@@ -2,7 +2,7 @@ namespace Fluent_CQRS
 {
     public interface ICollectEvents
     {
-        IReplayEvents WithId(string aggregateId);
-        IReplayEvents All();
+        IReplayEvents EventsWithAggregateId(string aggregateId);
+        IReplayEvents AllEvents();
     }
 }

--- a/src/Fluent-CQRS/IReplayEvents.cs
+++ b/src/Fluent-CQRS/IReplayEvents.cs
@@ -4,6 +4,6 @@
     {
         void To(IHandleEvents eventHandler);
         void ToAllEventHandlers();
-        IReplayEvents OfMessageType<T>() where T:IAmAnEventMessage;
+        IReplayEvents OfType<T>() where T:IAmAnEventMessage;
     }
 }

--- a/src/Fluent-CQRS/PlaybackEvents.cs
+++ b/src/Fluent-CQRS/PlaybackEvents.cs
@@ -16,14 +16,14 @@ namespace Fluent_CQRS
             _replayCallback = replayCallback;
         }
 
-        public IReplayEvents WithId(string aggregateId)
+        public IReplayEvents EventsWithAggregateId(string aggregateId)
         {
             _currentAggregateEvents = _eventStore.RetrieveFor<TAggregate>(aggregateId);
 
             return this;
         }
 
-        public IReplayEvents All()
+        public IReplayEvents AllEvents()
         {
             _currentAggregateEvents = _eventStore.RetrieveFor<TAggregate>();
 
@@ -40,7 +40,7 @@ namespace Fluent_CQRS
             _replayCallback(_currentAggregateEvents);
         }
 
-        public IReplayEvents OfMessageType<TEvent>() where TEvent : IAmAnEventMessage
+        public IReplayEvents OfType<TEvent>() where TEvent : IAmAnEventMessage
         {
             _currentAggregateEvents = _currentAggregateEvents.OfType<TEvent>() as IEnumerable<IAmAnEventMessage> ;
             return this;


### PR DESCRIPTION
Renaming 

    _aggregates
        .ReplayEventsFor<[AnAggregateYouLike]>()
        .All() | .WithId(aggrId)
        .OfMessageType<[AnEvent]>()
        .ToAllEventHandlers();

to

    _aggregates
        .ReplayFor<[AnAggregateYouLike]>()
        .AllEvents() | .EventsWithAggregateId(aggrId)
        .OfType<[AnEvent]>()
        .ToAllEventHandlers() | .To([OneOfYourEventHandler]);
